### PR TITLE
fix partner image width

### DIFF
--- a/2019/src/scss/_global.scss
+++ b/2019/src/scss/_global.scss
@@ -262,7 +262,7 @@ h2 + .partners {
 }
 
 .partner-logo {
-  max-width: 320px;
+  max-width: 250px;
   vertical-align: middle;
   margin: 0.5rem 2rem;
 


### PR DESCRIPTION
The current width makes the Digital Ocean logo too wide on mobile devices and creates the following effect (ability to scroll horizontally):

![demo](https://imgur.com/9bbbFum.png)